### PR TITLE
Rewrite async callback identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,7 @@ All of this is pretty standard stuff, there's two things to note here though:
 ### Adding middleware
 
 Middleware is added mainly with the `pre` and `post` methods. 
-`grappling-hook` allows you to add both sync and async functions. An async middleware function simply declares a `next` parameter last.
-
-**N.B.**: This parameter _has_ to be called `next` or `callback`, otherwise it won't be recognized as being an async function.
+`grappling-hook` allows you to add both sync and async functions. An async middleware function simply accepts an extra callback function.
 
 ```js
 instance.pre('save', function(next){

--- a/index.js
+++ b/index.js
@@ -44,10 +44,16 @@ function addMiddleware(instance, hook, args) {
 }
 
 function iterateMiddleware(context, middleware, args, done) {
+	args = args || [];
 	async.eachSeries(middleware, function(callback, next) {
-		di(callback, context, {callback: ['next', 'callback']}).provides(args).call(function(err) {
-			next(err);
-		});
+		if(callback.length>args.length){
+			//async
+			callback.apply(context, args.concat(next));
+		}else{
+			//sync
+			callback.apply(context, args);
+			next();
+		}
 	}, done || function(err) {
 		if (err) {
 			throw err;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var _ = require('lodash'),
 function init(opts) {
 	this.__grappling = {
 		middleware: {},
-		hooks: [],
-		opts: _.defaults({}, opts, {
+		hooks     : [],
+		opts      : _.defaults({}, opts, {
 			strict: true
 		})
 	};
@@ -45,20 +45,19 @@ function addMiddleware(instance, hook, args) {
 function iterateMiddleware(context, middleware, args, done) {
 	args = args || [];
 	async.eachSeries(middleware, function(callback, next) {
-		if(callback.length>args.length){
-			//async
-			callback.apply(context, args.concat(next));
-		}else{
-			//sync
-			callback.apply(context, args);
-			next();
-		}
-	}, done || function(err) {
-		if (err) {
-			throw err;
-		}
+			if (callback.length > args.length) {
+				//async
+				callback.apply(context, args.concat(next));
+			} else {
+				//sync
+				callback.apply(context, args);
+				next();
+			}
+		}, done || function(err) {
+			if (err) {
+				throw err;
+			}
 	});
-
 }
 
 /**
@@ -82,7 +81,7 @@ function createHooks(instance, config) {
 				n = args.length - 1,
 				middleware = instance.getMiddleware('pre:' + hookObj.name),
 				callback = _.isFunction(args[n]) ? args.shift() : undefined;
-			middleware.push(function(next){
+			middleware.push(function(next) {
 				args.push(next);
 				fn.apply(instance, args);
 			});
@@ -296,7 +295,7 @@ function create(opts) {
 }
 
 module.exports = {
-	mixin: mixin,
+	mixin : mixin,
 	create: create,
 	attach: attach
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash'),
-	di = require('asyncdi'),
 	async = require('async');
 
 function init(opts) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/keystonejs/keystone-hooks",
   "dependencies": {
     "async": "^0.9.0",
-    "asyncdi": "^1.1.0",
     "lodash": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
ATM middleware will be executed async if the final argument of the middleware function is called `next` or `callback`, but I’d like to change this behaviour for a few reasons: some time in the future I’d like to
- make grappling-hook middleware registration to be fully compatible with mongoose hook callback registration
- make grappling-hook isomorphic, and the current implementation will raise some serious trouble, since it depends on argument names. When the middleware functions are minified `next` will be renamed to `c` or something

So, what I propose is the following: instead of checking the name, I’d check the number of parameters the callback function accepts, if this is 1 more than the number of parameters passed to `callHook` :arrow_right: bingo, it’s async

Extra benefit: it would make grappling-hook backwards-compatible, i.e. we could push grappling-hook into keystone 0.3.x
