### PR TITLE
Parallel middleware registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha tests.js",
-    "lint": "eslint ./; true",
+    "lint": "eslint index.js tests.js; true",
     "test-cov": "istanbul cover _mocha tests.js",
     "travis": "npm test; npm run lint"
   },


### PR DESCRIPTION
So, this allows the registration of parallel middleware through `pre("hook", function(next, done){})`

Now we have:
- sync: `pre("hook", function(){})`
- async serial: `pre("hook", function(next){})`
- async parallel: `pre("hook", function(next, done){})`
